### PR TITLE
Toggle quest nodes with single button

### DIFF
--- a/src/modules/canvas/Canvas.tsx
+++ b/src/modules/canvas/Canvas.tsx
@@ -13,6 +13,7 @@ export const Canvas = () => {
   const [cursorMode, setCursorMode] = useState<CursorModeType>("normal");
   const [connectionStart, setConnectionStart] = useState<string | null>(null);
   const [, setViewMode] = useState<ViewModeType>("canvas");
+  const [areNodesCollapsed, setAreNodesCollapsed] = useState(false);
 
   const { screenToFlowPosition } = useReactFlow();
 
@@ -37,6 +38,18 @@ export const Canvas = () => {
     addQuestNode,
     screenToFlowPosition,
   });
+
+  const toggleCollapseAll = useCallback(() => {
+    if (areNodesCollapsed) {
+      expandAll();
+      setAreNodesCollapsed(false);
+      setCursorMode("expand");
+    } else {
+      collapseAll();
+      setAreNodesCollapsed(true);
+      setCursorMode("collapse");
+    }
+  }, [areNodesCollapsed, collapseAll, expandAll, setCursorMode]);
 
   // - If no start point is selected, stores the clicked node's id.
   // - Otherwise, connects the start node to the clicked node and resets the selection.
@@ -74,6 +87,8 @@ export const Canvas = () => {
         setViewMode={setViewMode}
         collapseAll={collapseAll}
         expandAll={expandAll}
+        areNodesCollapsed={areNodesCollapsed}
+        toggleCollapseAll={toggleCollapseAll}
         onSaveCanvas={() => saveCanvas()}
       />
     </div>

--- a/src/modules/canvas/canvas.type.ts
+++ b/src/modules/canvas/canvas.type.ts
@@ -9,6 +9,8 @@ export type FloatingToolboxProps = {
   setViewMode: (mode: ViewModeType) => void;
   collapseAll: () => void;
   expandAll: () => void;
+  areNodesCollapsed: boolean;
+  toggleCollapseAll: () => void;
 };
 
 export type SkillConfigType = {

--- a/src/modules/canvas/components/CanvasView.tsx
+++ b/src/modules/canvas/components/CanvasView.tsx
@@ -35,6 +35,8 @@ type CanvasViewProps = {
   className?: string;
   collapseAll: () => void;
   expandAll: () => void;
+  areNodesCollapsed: boolean;
+  toggleCollapseAll: () => void;
   onSaveCanvas: () => void;
 };
 
@@ -61,6 +63,8 @@ export const CanvasView = ({
   setViewMode,
   collapseAll,
   expandAll,
+  areNodesCollapsed,
+  toggleCollapseAll,
   onSaveCanvas,
 }: CanvasViewProps) => {
   const navigate = useNavigate();
@@ -155,6 +159,8 @@ export const CanvasView = ({
         setViewMode={setViewMode}
         collapseAll={collapseAll}
         expandAll={expandAll}
+        areNodesCollapsed={areNodesCollapsed}
+        toggleCollapseAll={toggleCollapseAll}
       />
 
       {/* Mode Indicators */}

--- a/src/modules/canvas/components/floating-toolbox/FloatingToolbox.tsx
+++ b/src/modules/canvas/components/floating-toolbox/FloatingToolbox.tsx
@@ -1,6 +1,7 @@
-import type { FloatingToolboxProps } from "../../canvas.type";
+import type { FloatingToolboxProps, CursorModeType } from "../../canvas.type";
 import { ToolButton } from "./ToolButton";
 import { tools } from "./toolbox.const";
+import { ChevronsDownUp, Maximize2 } from "lucide-react";
 
 export const FloatingToolbox = ({
   cursorMode,
@@ -8,17 +9,45 @@ export const FloatingToolbox = ({
   // setViewMode,
   collapseAll,
   expandAll,
-}: FloatingToolboxProps) => (
-  <div className="absolute top-6 right-6 z-20 bg-white/90 backdrop-blur-sm rounded-xl shadow-lg border border-gray-200/50 p-2 flex flex-col gap-1">
-    {tools.map((tool) => (
-      <ToolButton
-        key={tool.id}
-        tool={tool}
-        cursorMode={cursorMode}
-        setCursorMode={setCursorMode}
-        colllapseAll={collapseAll}
-        expandAll={expandAll}
-      />
-    ))}
-  </div>
-);
+  areNodesCollapsed,
+  toggleCollapseAll,
+}: FloatingToolboxProps) => {
+  const collapseExpandTool = areNodesCollapsed
+    ? {
+        id: "collapse",
+        icon: <ChevronsDownUp className="w-5 h-5" />,
+        tooltip: "Collapse All Quests",
+        activeColor: "bg-gray-600 hover:bg-gray-700 text-white",
+        isActive: (mode: CursorModeType) => mode === "collapse",
+        handleToolClick: () => {
+          toggleCollapseAll();
+        },
+      }
+    : {
+        id: "expand",
+        icon: <Maximize2 className="w-5 h-5 transform rotate-180" />,
+        tooltip: "Expand All Quests",
+        activeColor: "bg-gray-600 hover:bg-gray-700 text-white",
+        isActive: (mode: CursorModeType) => mode === "expand",
+        handleToolClick: () => {
+          toggleCollapseAll();
+        },
+      };
+
+  const allTools = [...tools, collapseExpandTool];
+
+  return (
+    <div className="absolute top-6 right-6 z-20 bg-white/90 backdrop-blur-sm rounded-xl shadow-lg border border-gray-200/50 p-2 flex flex-col gap-1">
+      {allTools.map((tool) => (
+        <ToolButton
+          key={tool.id}
+          tool={tool}
+          cursorMode={cursorMode}
+          setCursorMode={setCursorMode}
+          colllapseAll={collapseAll}
+          expandAll={expandAll}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/modules/canvas/components/floating-toolbox/toolbox.const.tsx
+++ b/src/modules/canvas/components/floating-toolbox/toolbox.const.tsx
@@ -1,4 +1,4 @@
-import { Link, Plus, Target, Map, ChevronsDownUp, Maximize2 } from "lucide-react";
+import { Link, Plus, Target, Map } from "lucide-react";
 import type { CursorModeType, ViewModeType } from "../../canvas.type";
 
 export type ToolBoxItem = {
@@ -44,28 +44,6 @@ export const tools: ToolboxList = [
     activeColor: "bg-gray-600 hover:bg-gray-700 text-white",
     isActive: (mode) => mode === "normal",
     handleToolClick: (setCursorMode) => setCursorMode("normal"),
-  },
-  {
-    id: "collapse",
-    icon: <ChevronsDownUp className="w-5 h-5" />,
-    tooltip: "Collapse All Quests",
-    activeColor: "bg-gray-600 hover:bg-gray-700 text-white",
-    isActive: (mode) => mode === "collapse",
-    handleToolClick: (setCursorMode, current, ctx) => {
-      ctx?.collapseAll?.();
-      setCursorMode(current === "collapse" ? "normal" : "collapse");
-    },
-  },
-  {
-    id: "expand",
-    icon: <Maximize2 className="w-5 h-5 transform rotate-180" />,
-    tooltip: "Expand All Quests",
-    activeColor: "bg-gray-600 hover:bg-gray-700 text-white",
-    isActive: (mode) => mode === "expand",
-    handleToolClick: (setCursorMode, current, ctx) => {
-      ctx?.expandAll?.();
-      setCursorMode(current === "expand" ? "normal" : "expand");
-    },
   },
   {
     id: "roadmap",


### PR DESCRIPTION
## Summary
- simplify toolbox icon list
- manage node collapse state in Canvas
- pass collapse toggle state to `CanvasView` and `FloatingToolbox`
- render a dynamic collapse/expand button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686adf45cf688320bdc4c562d16195d1